### PR TITLE
Added basic tests

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -17,6 +17,9 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring-boot.version>2.0.0.RELEASE</spring-boot.version>
+        <junit.version>4.12</junit.version>
+        <spring-test.version>5.0.4.RELEASE</spring-test.version>
+        <mockito.version>1.10.19</mockito.version>
     </properties>
 
     <distributionManagement>
@@ -50,6 +53,27 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
+        </dependency>
+
+        <!-- Test Dependencies -->
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring-test.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/lib/src/test/java/com/verygoodsecurity/spring/ApplicationContextTest.java
+++ b/lib/src/test/java/com/verygoodsecurity/spring/ApplicationContextTest.java
@@ -1,0 +1,33 @@
+package com.verygoodsecurity.spring;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.web.client.RestTemplate;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {VgsProxyConfiguration.class, RestTemplateConfig.class}, loader= AnnotationConfigContextLoader.class)
+@TestPropertySource("classpath:application.properties")
+public class ApplicationContextTest extends AbstractJUnit4SpringContextTests {
+
+  @Autowired
+  private ApplicationContext applicationContext;
+
+  @Value("${vgs.proxy.url}")
+  private String forwardProxyUrl;
+
+  @Test
+  public void testAppContext() {
+    applicationContext.getBean(RestTemplate.class);
+  }
+
+
+
+}

--- a/lib/src/test/java/com/verygoodsecurity/spring/RestTemplateConfig.java
+++ b/lib/src/test/java/com/verygoodsecurity/spring/RestTemplateConfig.java
@@ -1,0 +1,20 @@
+package com.verygoodsecurity.spring;
+
+import com.verygoodsecurity.spring.annotation.EnableVgsProxy;
+import com.verygoodsecurity.spring.annotation.VgsProxied;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+@EnableVgsProxy
+public class RestTemplateConfig {
+
+  @Bean
+  @VgsProxied
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+
+}

--- a/lib/src/test/java/com/verygoodsecurity/spring/VgsProxyConfigurationTest.java
+++ b/lib/src/test/java/com/verygoodsecurity/spring/VgsProxyConfigurationTest.java
@@ -1,0 +1,58 @@
+package com.verygoodsecurity.spring;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.Collections;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VgsProxyConfigurationTest {
+
+  private static final String TRUST_STORE_RESOURCE_NAME = "certs/vgs-proxy.jks";
+  private static final String TRUST_STORE_PASSWORD = "verygoodproxy";
+  private static final String forwardProxyUrl = "https://username:password@subdomain.SANDBOX.verygoodproxy.io:8080";
+
+  private RestTemplate restTemplate;
+
+  private VgsProxyConfiguration vgsProxyConfiguration;
+
+  @Before
+  public void setUp() {
+    restTemplate = Mockito.mock(RestTemplate.class);
+    vgsProxyConfiguration = new VgsProxyConfiguration(forwardProxyUrl);
+    vgsProxyConfiguration.setRestTemplates(Collections.singletonList(restTemplate));
+  }
+
+  @Test
+  public void testConfigureRestTemplates() {
+    // When
+    vgsProxyConfiguration.configureRestTemplates();
+
+    // Then
+    verify(restTemplate).setRequestFactory(any());
+  }
+
+  @Test
+  public void testKeyStoreLoads() throws IOException, CertificateException, NoSuchAlgorithmException, KeyStoreException {
+    final ClassLoader classLoader = getClass().getClassLoader();
+    final KeyStore vgsProxyCerts = KeyStore.getInstance(KeyStore.getDefaultType());
+    try (InputStream inputStream = classLoader.getResourceAsStream(TRUST_STORE_RESOURCE_NAME)) {
+      vgsProxyCerts.load(inputStream, TRUST_STORE_PASSWORD.toCharArray());
+    }
+  }
+
+}

--- a/lib/src/test/resources/application.properties
+++ b/lib/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+vgs.proxy.url=https://username:password@subdomain.SANDBOX.verygoodproxy.io:8080


### PR DESCRIPTION
Fixes https://app.clubhouse.io/vgs/story/8015/add-tests-to-vgs-proxy-spring

Added basic tests for RestTemplate config and context loading.
As RestTemplate initializes and uses internal package private classes we can not use Reflection utils to get credentials and httpclient to check values inside.
Cases that covered in PR are those that are accessible via visible methods.